### PR TITLE
Add agent workflow docs and knowledge graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # lawyerfactory
+
+This repository contains an experimental agent-based workflow for generating long-form legal content. The approach relies on a team of specialized GPT-4.1-mini agents managed in an assembly-line fashion.
+
+See [docs/team_chart.md](docs/team_chart.md) for an overview of the agents and phases.
+
+The knowledge graph describing entities and relationships is stored in `knowledge_graph.json` and can be updated via `knowledge_graph.py`.
+
+

--- a/docs/team_chart.md
+++ b/docs/team_chart.md
@@ -1,0 +1,16 @@
+# Agent Team Chart
+
+The project follows an assembly-line approach involving specialized GPT-4.1-mini agents. Each phase represents a step in the process with human review at critical points.
+
+| Phase | Purpose | Agents Involved |
+|------|---------|----------------|
+| 1. Intake | Gather user prompt and uploaded documents. Extract facts and key terms. Set up primary/secondary evidence databases. | **Maestro**, Reader, Paralegal |
+| 2. Outline | Identify legal area, jurisdiction, grounds for recovery. Draft outline and raise outstanding questions for user. | Outliner, Paralegal |
+| 3. Research | Conduct background research and locate relevant caselaw. Build knowledge base and caselaw database. | Researcher, Legal Researcher |
+| 4. Drafting | Produce modular content following "Law of Threes" structure. | Writer, Paralegal |
+| 5. Legal Review | Apply legal formatting, procedure checks, and ensure IRAC compliance. | Legal Formatter, Legal Procedure Agent |
+| 6. Editing | Review for clarity, style, and coherence. | Editor |
+| 7. Orchestration | Manage flow between phases and coordinate agents. | **Maestro** |
+
+Human approval is required after phases 2, 3, 4, and 6.
+

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,53 @@
+{
+  "entities": [
+    {
+      "id": "Maestro",
+      "type": "agent",
+      "features": ["orchestration", "coordination"]
+    },
+    {
+      "id": "Reader",
+      "type": "agent",
+      "features": ["document intake", "fact extraction"]
+    },
+    {
+      "id": "Outliner",
+      "type": "agent",
+      "features": ["outline creation", "gap identification"]
+    },
+    {
+      "id": "Writer",
+      "type": "agent",
+      "features": ["drafting", "Law of Threes"]
+    },
+    {
+      "id": "Editor",
+      "type": "agent",
+      "features": ["style", "coherence"]
+    },
+    {
+      "id": "Paralegal",
+      "type": "agent",
+      "features": ["jurisdiction", "evidence tagging"]
+    },
+    {
+      "id": "Legal Researcher",
+      "type": "agent",
+      "features": ["caselaw search"]
+    },
+    {
+      "id": "Legal Formatter",
+      "type": "agent",
+      "features": ["legal citation", "IRAC formatting"]
+    },
+    {
+      "id": "Legal Procedure Agent",
+      "type": "agent",
+      "features": ["procedure compliance", "form retrieval"]
+    }
+  ],
+  "relationships": [],
+  "observations": [
+    "Initial setup of agents for assembly-line legal drafting project"
+  ]
+}

--- a/knowledge_graph.py
+++ b/knowledge_graph.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+GRAPH_PATH = Path('knowledge_graph.json')
+
+def load_graph():
+    if GRAPH_PATH.exists():
+        with open(GRAPH_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {"entities": [], "relationships": [], "observations": []}
+
+
+def save_graph(graph):
+    with open(GRAPH_PATH, 'w', encoding='utf-8') as f:
+        json.dump(graph, f, indent=2)
+
+
+def add_observation(text):
+    graph = load_graph()
+    graph.setdefault("observations", []).append(text)
+    save_graph(graph)
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        add_observation(' '.join(sys.argv[1:]))
+    else:
+        print(json.dumps(load_graph(), indent=2))


### PR DESCRIPTION
## Summary
- document multi-agent workflow using specialized GPT-4.1-mini agents
- add knowledge graph JSON file with initial agent entities
- provide script to update graph
- mention workflow and graph in README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684615dab324832aa39855f94eb3a680