### PR TITLE
Implement assessor document intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # lawyerfactory
+
+This repository contains a simple document intake system.
+
+## Assessor
+
+The `assessor.py` script ingests text documents and stores metadata
+in `repository.csv`. It automatically generates a short summary,
+assigns a category based on keywords, and adds a hashtag.
+
+Run the script from the command line:
+
+```bash
+python assessor.py path/to/document.txt --author "Author Name" --title "Doc Title" --date YYYY-MM-DD
+```
+
+## Tests
+
+Install dependencies and run tests with `pytest`:
+
+```bash
+pip install -r requirements.txt  # or `pip install flake8 pytest nltk`
+flake8 .
+pytest -q
+```

--- a/assessor.py
+++ b/assessor.py
@@ -1,0 +1,73 @@
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+import nltk
+
+from repository import add_entry
+
+# Ensure NLTK sentence tokenizer data is available
+try:
+    nltk.data.find("tokenizers/punkt")
+    nltk.data.find("tokenizers/punkt_tab/english.pickle")
+except LookupError:
+    nltk.download("punkt")
+    nltk.download("punkt_tab")
+
+
+def summarize(text: str, max_sentences: int = 2) -> str:
+    """Return a naive summary consisting of the first `max_sentences` sentences."""
+    sentences = nltk.sent_tokenize(text)
+    return ' '.join(sentences[:max_sentences])
+
+
+def categorize(text: str) -> str:
+    """Categorize text using simple keyword rules."""
+    lowered = text.lower()
+    if 'contract' in lowered:
+        return 'contract'
+    if 'litigation' in lowered:
+        return 'litigation'
+    return 'general'
+
+
+def hashtags_from_category(category: str) -> str:
+    return f"#{category}"
+
+
+def intake_document(
+    author: str,
+    title: str,
+    publication_date: Optional[str],
+    text: str,
+) -> None:
+    """Process and store a new document in the repository."""
+    if publication_date is None:
+        publication_date = date.today().isoformat()
+    summary = summarize(text)
+    category = categorize(text)
+    hashtags = hashtags_from_category(category)
+    entry = {
+        'author': author,
+        'title': title,
+        'publication_date': publication_date,
+        'summary': summary,
+        'category': category,
+        'hashtags': hashtags,
+    }
+    add_entry(entry)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Intake a document into the repository')
+    parser.add_argument('file', type=Path, help='Path to a text file')
+    parser.add_argument('--author', required=True, help='Author of the document')
+    parser.add_argument('--title', required=True, help='Document title')
+    parser.add_argument('--date', help='Publication date in YYYY-MM-DD format')
+    args = parser.parse_args()
+
+    text = args.file.read_text(encoding='utf-8')
+    intake_document(args.author, args.title, args.date, text)
+    print('Document ingested.')

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,32 @@
+{
+  "entities": [
+    {
+      "id": "Assessor",
+      "type": "Agent",
+      "features": [
+        "intake documents",
+        "organize list",
+        "AI summarization",
+        "categorization",
+        "hashtags"
+      ],
+      "relationships": {"Repository": "adds documents"}
+    },
+    {
+      "id": "Repository",
+      "type": "Database",
+      "features": [
+        "metadata fields (author, title, publication date, summary, category, hashtags)",
+        "CSV storage"
+      ],
+      "relationships": {"Legal Researcher": "source of documents"}
+    },
+    {
+      "id": "Legal Researcher",
+      "type": "Agent",
+      "features": ["research using repository"],
+      "relationships": {"Repository": "uses"}
+    }
+  ],
+  "observations": "Added assessor and repository modules with tests and documentation"
+}

--- a/repository.py
+++ b/repository.py
@@ -1,0 +1,35 @@
+import csv
+from pathlib import Path
+from typing import List, Dict
+
+REPO_FILE = Path('repository.csv')
+
+FIELDS = [
+    'author',
+    'title',
+    'publication_date',
+    'summary',
+    'category',
+    'hashtags',
+]
+
+def init_repo() -> None:
+    """Create repository file with headers if it doesn't exist."""
+    if not REPO_FILE.exists():
+        with REPO_FILE.open('w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDS)
+            writer.writeheader()
+
+def add_entry(entry: Dict[str, str]) -> None:
+    """Add a dictionary entry to the repository."""
+    init_repo()
+    with REPO_FILE.open('a', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writerow(entry)
+
+def list_entries() -> List[Dict[str, str]]:
+    """Return all repository entries."""
+    init_repo()
+    with REPO_FILE.open('r', newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        return list(reader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flake8
+pytest
+nltk

--- a/tests/test_assessor.py
+++ b/tests/test_assessor.py
@@ -1,0 +1,21 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import repository
+from assessor import intake_document
+
+
+def test_intake_document(tmp_path):
+    repo_file = tmp_path / 'repository.csv'
+    repository.REPO_FILE = repo_file
+    repository.init_repo()
+
+    text = 'This is a contract between parties. It outlines terms.'
+    intake_document('Alice', 'Contract A', '2023-01-01', text)
+
+    entries = repository.list_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry['author'] == 'Alice'
+    assert entry['title'] == 'Contract A'
+    assert entry['category'] == 'contract'
+    assert entry['hashtags'] == '#contract'
+


### PR DESCRIPTION
## Summary
- add `assessor.py` and `repository.py` for document intake
- store documents in `repository.csv` and summarize with NLTK
- provide tests for assessor
- document usage in README
- add basic requirements
- maintain knowledge graph

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847eebf8e00832a83f2f02bdb05cf4c