### PR TITLE
Add workflow modules and Kanban CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# lawyerfactory
+# LawyerFactory
+
+This project provides a simple workflow manager for building legal documents. It
+features sequential stages with human feedback loops and a basic Kanban board
+interface.
+Tasks can be assigned to agents and progressed through defined stages.
+Each action is logged to `knowledge_graph.json` for traceability.
+
+## Running
+
+```
+python app.py
+```
+
+## Tests and Linting
+
+Install dependencies and run:
+
+```
+pip install -r requirements.txt
+flake8
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from lawyerfactory.knowledge_graph import (
+    load_graph,
+    save_graph,
+    add_observation,
+)
+from lawyerfactory.models import Task
+from lawyerfactory.workflow import TaskBoard, progress_task
+from lawyerfactory.kanban_cli import display_board
+
+
+def main() -> None:
+    graph = load_graph()
+    add_observation(graph, "Application run")
+
+    board = TaskBoard()
+    board.add_task(Task(id=1, title="Prepare complaint"), graph)
+    board.add_task(Task(id=2, title="Draft summons"), graph)
+
+    board.assign_task(1, "ResearchAgent", graph)
+    board.assign_task(2, "DraftingAgent", graph)
+
+    print(display_board(board))
+
+    # Example progress through stages
+    progress_task(board.tasks[0], graph)
+    print("\nAfter progressing task 1:\n")
+    print(display_board(board))
+
+    save_graph(graph)
+
+
+if __name__ == "__main__":
+    main()

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,41 @@
+{
+  "entities": {
+    "Lawsuit": {
+      "features": [
+        "statement_of_facts",
+        "description_of_parties",
+        "cover_sheet"
+      ]
+    },
+    "Workflow": {
+      "stages": [
+        "Preproduction Planning",
+        "Research and Development",
+        "Organization / Database Building",
+        "1st Pass All Parts",
+        "Combining",
+        "Editing",
+        "2nd Pass",
+        "Human Feedback",
+        "Final Draft"
+      ]
+    },
+    "Agent": {
+      "features": [
+        "name",
+        "role"
+      ]
+    }
+  },
+  "relationships": {},
+  "observations": [
+    "Initial graph created.",
+    "Application run",
+    "Application run",
+    "Task 1 added at Preproduction Planning",
+    "Task 2 added at Preproduction Planning",
+    "Task 1 assigned to ResearchAgent",
+    "Task 2 assigned to DraftingAgent",
+    "Task 1 moved to Research and Development"
+  ]
+}

--- a/lawyerfactory/kanban_cli.py
+++ b/lawyerfactory/kanban_cli.py
@@ -1,0 +1,14 @@
+from .models import STAGE_SEQUENCE
+from .workflow import TaskBoard
+
+
+def display_board(board: TaskBoard) -> str:
+    lines = []
+    for stage in STAGE_SEQUENCE:
+        tasks = board.tasks_by_stage().get(stage, [])
+        task_list = ', '.join(
+            f"{t.id}:{t.title}" + (f" ({t.assignee})" if t.assignee else "")
+            for t in tasks
+        ) or '-'
+        lines.append(f"{stage.value}: {task_list}")
+    return '\n'.join(lines)

--- a/lawyerfactory/knowledge_graph.py
+++ b/lawyerfactory/knowledge_graph.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+KNOWLEDGE_GRAPH_PATH = Path("knowledge_graph.json")
+
+DEFAULT_GRAPH: Dict[str, Any] = {
+    "entities": {
+        "Lawsuit": {
+            "features": [
+                "statement_of_facts",
+                "description_of_parties",
+                "cover_sheet",
+            ]
+        },
+        "Workflow": {
+            "stages": [
+                "Preproduction Planning",
+                "Research and Development",
+                "Organization / Database Building",
+                "1st Pass All Parts",
+                "Combining",
+                "Editing",
+                "2nd Pass",
+                "Human Feedback",
+                "Final Draft",
+            ]
+        },
+    },
+    "relationships": {},
+    "observations": ["Initial graph created."],
+}
+
+
+def load_graph() -> Dict[str, Any]:
+    if KNOWLEDGE_GRAPH_PATH.exists():
+        with KNOWLEDGE_GRAPH_PATH.open("r") as fh:
+            return json.load(fh)
+    return DEFAULT_GRAPH
+
+
+def save_graph(graph: Dict[str, Any]) -> None:
+    with KNOWLEDGE_GRAPH_PATH.open("w") as fh:
+        json.dump(graph, fh, indent=2)
+
+
+def add_observation(graph: Dict[str, Any], observation: str) -> None:
+    graph.setdefault("observations", []).append(observation)

--- a/lawyerfactory/models.py
+++ b/lawyerfactory/models.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Stage(Enum):
+    PREPRODUCTION_PLANNING = "Preproduction Planning"
+    RESEARCH_AND_DEVELOPMENT = "Research and Development"
+    ORGANIZATION_DATABASE_BUILDING = "Organization / Database Building"
+    FIRST_PASS = "1st Pass All Parts"
+    COMBINING = "Combining"
+    EDITING = "Editing"
+    SECOND_PASS = "2nd Pass"
+    HUMAN_FEEDBACK = "Human Feedback"
+    FINAL_DRAFT = "Final Draft"
+
+
+STAGE_SEQUENCE = [
+    Stage.PREPRODUCTION_PLANNING,
+    Stage.RESEARCH_AND_DEVELOPMENT,
+    Stage.ORGANIZATION_DATABASE_BUILDING,
+    Stage.FIRST_PASS,
+    Stage.COMBINING,
+    Stage.EDITING,
+    Stage.SECOND_PASS,
+    Stage.HUMAN_FEEDBACK,
+    Stage.FINAL_DRAFT,
+
+]
+
+
+@dataclass
+class Task:
+    id: int
+    title: str
+    stage: Stage = Stage.PREPRODUCTION_PLANNING
+    description: str = ""
+    assignee: str | None = None
+
+    def assign(self, agent: str) -> None:
+        """Assign this task to an agent."""
+        self.assignee = agent
+
+    def advance(self) -> None:
+        """Advance the task to the next stage."""
+        current_index = STAGE_SEQUENCE.index(self.stage)
+        if current_index < len(STAGE_SEQUENCE) - 1:
+            self.stage = STAGE_SEQUENCE[current_index + 1]

--- a/lawyerfactory/workflow.py
+++ b/lawyerfactory/workflow.py
@@ -1,0 +1,44 @@
+from typing import List
+from .models import Task, STAGE_SEQUENCE
+from .knowledge_graph import add_observation
+
+
+def progress_task(task: Task, graph: dict | None = None) -> None:
+    """Advance a task to the next stage and optionally log it."""
+    task.advance()
+    if graph is not None:
+        msg = f"Task {task.id} moved to {task.stage.value}"
+        add_observation(graph, msg)
+
+
+def is_complete(task: Task) -> bool:
+    """Return True if the task is at the final stage."""
+    return task.stage == STAGE_SEQUENCE[-1]
+
+
+class TaskBoard:
+    def __init__(self, tasks: List[Task] | None = None) -> None:
+        self.tasks: List[Task] = tasks or []
+
+    def add_task(self, task: Task, graph: dict | None = None) -> None:
+        self.tasks.append(task)
+        if graph is not None:
+            msg = f"Task {task.id} added at {task.stage.value}"
+            add_observation(graph, msg)
+
+    def assign_task(
+        self, task_id: int, agent: str, graph: dict | None = None
+    ) -> None:
+        for task in self.tasks:
+            if task.id == task_id:
+                task.assign(agent)
+                if graph is not None:
+                    msg = f"Task {task.id} assigned to {agent}"
+                    add_observation(graph, msg)
+                break
+
+    def tasks_by_stage(self) -> dict:
+        result: dict = {stage: [] for stage in STAGE_SEQUENCE}
+        for task in self.tasks:
+            result[task.stage].append(task)
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/tests/test_kanban.py
+++ b/tests/test_kanban.py
@@ -1,0 +1,16 @@
+import pathlib
+import sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from lawyerfactory.models import Task  # noqa: E402
+from lawyerfactory.workflow import TaskBoard  # noqa: E402
+from lawyerfactory.kanban_cli import display_board  # noqa: E402
+
+
+def test_display_board_formats_tasks():
+    board = TaskBoard()
+    task = Task(id=1, title="Task1", assignee="Agent")
+    board.add_task(task)
+    output = display_board(board)
+    assert "Task1" in output
+    assert "Agent" in output

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,20 @@
+import pathlib
+import sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from lawyerfactory.models import Task, Stage  # noqa: E402
+from lawyerfactory.workflow import progress_task, is_complete  # noqa: E402
+
+
+def test_progress_task_advances_stage_and_logs():
+    task = Task(id=1, title="example")
+    graph = {"observations": []}
+    assert task.stage == Stage.PREPRODUCTION_PLANNING
+    progress_task(task, graph)
+    assert task.stage == Stage.RESEARCH_AND_DEVELOPMENT
+    assert graph["observations"]
+
+
+def test_is_complete():
+    task = Task(id=1, title="example", stage=Stage.FINAL_DRAFT)
+    assert is_complete(task)


### PR DESCRIPTION
## Summary
- implement data models, workflow utilities, and Kanban board helper
- add CLI demo app and knowledge graph support
- provide tests for workflow and Kanban features
- document usage and developer instructions
- add task assignments and graph logging

## Testing
- `flake8`
- `pytest -q`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6859181e5968832ababca96a1bdbcbe3