### PR TITLE
Add initial knowledge graph module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # lawyerfactory
+
+This repository provides a small knowledge graph utility.
+
+## Knowledge Graph Module
+
+The `knowledge_graph.py` module loads and saves `knowledge_graph.json`, which
+tracks entities, their features and relationships. You can use the helper
+functions to load the graph, add entities or relationships, append
+observations, and save the updated graph.
+
+Example usage:
+
+```python
+from knowledge_graph import load_graph, save_graph, add_observation
+
+graph = load_graph()
+add_observation(graph, "Used the knowledge graph module.")
+save_graph(graph)
+```

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,19 @@
+{
+  "entities": [
+    {
+      "id": "LawyerFactory",
+      "features": ["repository", "agent tasks"]
+    },
+    {
+      "id": "knowledge_graph",
+      "features": ["stores context", "updated per task"]
+    }
+  ],
+  "relationships": [
+    {"source": "LawyerFactory", "target": "knowledge_graph", "type": "contains"},
+    {"source": "knowledge_graph", "target": "LawyerFactory", "type": "context-for"}
+  ],
+  "observations": [
+    "Initialized knowledge graph module with load and save capabilities."
+  ]
+}

--- a/knowledge_graph.py
+++ b/knowledge_graph.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+KGRAPH_FILE = Path(__file__).resolve().parent / "knowledge_graph.json"
+
+
+def load_graph(file_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the knowledge graph from a JSON file."""
+    path = file_path or KGRAPH_FILE
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"entities": [], "relationships": [], "observations": []}
+
+
+def save_graph(
+    graph: Dict[str, Any], file_path: Optional[Path] = None
+) -> None:
+    """Save the knowledge graph to a JSON file."""
+    path = file_path or KGRAPH_FILE
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(graph, f, indent=2, ensure_ascii=False)
+
+
+def add_entity(graph: Dict[str, Any], entity: Dict[str, Any]) -> None:
+    """Append an entity to the knowledge graph."""
+    graph.setdefault("entities", []).append(entity)
+
+
+def add_relationship(
+    graph: Dict[str, Any], relationship: Dict[str, Any]
+) -> None:
+    """Append a relationship to the knowledge graph."""
+    graph.setdefault("relationships", []).append(relationship)
+
+
+def add_observation(graph: Dict[str, Any], observation: str) -> None:
+    """Append an observation to the knowledge graph."""
+    graph.setdefault("observations", []).append(observation)


### PR DESCRIPTION
## Summary
- add knowledge graph module with helpers to load and save json
- provide initial `knowledge_graph.json` storing entities and relationships
- document module usage in README

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685f04925500832aa9c43217a6284fe1