### PR TITLE
Add modular lawsuit blueprint, document-object mapping, prewriting packets, Maestro accessors, and unit tests

### DIFF
--- a/docs/knowledge_graph_state.json
+++ b/docs/knowledge_graph_state.json
@@ -58,7 +58,7 @@
       "id": "workflow.lawsuit_phase_sequence",
       "type": "workflow",
       "name": "Lawsuit phase sequence",
-      "notes": "phaseA01_intake → phaseA02_research → phaseA03_outline → phaseB01_review → phaseB02_drafting → phaseC01_editing → phaseC02_orchestration"
+      "notes": "phaseA01_intake \u2192 phaseA02_research \u2192 phaseA03_outline \u2192 phaseB01_review \u2192 phaseB02_drafting \u2192 phaseC01_editing \u2192 phaseC02_orchestration"
     },
     {
       "id": "storage.enhanced_unified_storage_api",
@@ -66,6 +66,27 @@
       "name": "Enhanced unified storage API shim",
       "path": "src/lawyerfactory/storage/enhanced_unified_storage_api.py",
       "notes": "Compatibility re-export for unified storage API."
+    },
+    {
+      "id": "workflow.stage_blueprint",
+      "type": "component",
+      "name": "Stage-based lawsuit blueprint",
+      "path": "src/lawyerfactory/compose/maestro/lawsuit_blueprint.py",
+      "notes": "Defines discrete combinable phases from evidence/RAG ingestion through final compilation with a Head Partner role."
+    },
+    {
+      "id": "workflow.document_object_map",
+      "type": "component",
+      "name": "Document object map",
+      "path": "src/lawyerfactory/compose/maestro/document_object_map.py",
+      "notes": "Tracks section-by-claim/theory links, overlap detection, and context-window compression packets."
+    },
+    {
+      "id": "workflow.prewriting_packets",
+      "type": "component",
+      "name": "Pre-writing review packet generator",
+      "path": "src/lawyerfactory/compose/maestro/prewriting_packets.py",
+      "notes": "Builds three mandatory pre-writing deliverables for user review gate."
     }
   ],
   "features": [
@@ -91,6 +112,30 @@
       "type": "feature",
       "name": "Tiered evidence ingestion",
       "notes": "Adds primary/secondary/tertiary evidence tiers with tagging for source indexing."
+    },
+    {
+      "id": "workflow.evidence_cycle_payload",
+      "type": "feature",
+      "name": "Evidence cycle payload builder",
+      "notes": "Builds iterative primary/secondary/tertiary evidence buckets for repeated ingest and categorization loops."
+    },
+    {
+      "id": "workflow.context_window_packet",
+      "type": "feature",
+      "name": "Context-window-safe document packet",
+      "notes": "Compresses section summaries under token budget and preserves section location metadata."
+    },
+    {
+      "id": "workflow.prewriting_user_gate",
+      "type": "feature",
+      "name": "Three deliverable pre-writing gate",
+      "notes": "Evidence reliability brief, issue-fact matrix, and claim-theory strategy sheet must be reviewed before drafting."
+    },
+    {
+      "id": "workflow.debug_observability",
+      "type": "feature",
+      "name": "Detailed orchestration debug logging",
+      "notes": "Adds structured logs for blueprint generation, evidence cycle construction, pre-writing packet serialization, and document-map overlap/context-packet builds."
     }
   ],
   "relations": [
@@ -119,6 +164,41 @@
       "source": "workflow.maestro_agent",
       "type": "depends_on",
       "target": "storage.enhanced_unified_storage_api"
+    },
+    {
+      "source": "workflow.maestro_agent",
+      "type": "exposes",
+      "target": "workflow.stage_blueprint"
+    },
+    {
+      "source": "workflow.stage_blueprint",
+      "type": "extends",
+      "target": "evidence.tiered_classification"
+    },
+    {
+      "source": "workflow.maestro_agent",
+      "type": "exposes",
+      "target": "workflow.document_object_map"
+    },
+    {
+      "source": "workflow.maestro_agent",
+      "type": "exposes",
+      "target": "workflow.prewriting_packets"
+    },
+    {
+      "source": "workflow.document_object_map",
+      "type": "supports",
+      "target": "workflow.context_window_packet"
+    },
+    {
+      "source": "workflow.prewriting_packets",
+      "type": "implements",
+      "target": "workflow.prewriting_user_gate"
+    },
+    {
+      "source": "workflow.maestro_agent",
+      "type": "observes",
+      "target": "workflow.debug_observability"
     }
   ],
   "notes": [
@@ -133,6 +213,18 @@
     {
       "id": "note.lint_backlog",
       "text": "Repo-wide Ruff linting fails due to legacy violations; limiting lint scope or remediating existing files is required for a clean run."
+    },
+    {
+      "id": "note.stage_blueprint_scope",
+      "text": "Blueprint enforces phase order: evidence+RAG -> issue spot -> analysis -> fact lists -> causes of action -> top sheet -> compile."
+    },
+    {
+      "id": "note.claim_section_linking",
+      "text": "Sections are now mapped by underlying claim_id and theory_id to prevent overlap/repetition and preserve modular assembly."
+    },
+    {
+      "id": "note.logging_scope_modular_workflow",
+      "text": "Logging now emits counts, IDs, token budget usage, and overlap indicators to accelerate troubleshooting of modular long-form workflow stages."
     }
   ],
   "updates": [
@@ -147,6 +239,18 @@
     {
       "timestamp": "2025-02-14T02:00:00Z",
       "summary": "Captured tiered evidence ingestion for primary, secondary, and tertiary evidence tagging."
+    },
+    {
+      "timestamp": "2026-02-27T00:00:00Z",
+      "summary": "Added modular lawsuit stage blueprint, maestro accessors, and unit tests for evidence cycling + phase order."
+    },
+    {
+      "timestamp": "2026-02-27T01:00:00Z",
+      "summary": "Added document object map compression/linking and three pre-writing deliverables with maestro accessors and unit tests."
+    },
+    {
+      "timestamp": "2026-02-27T02:00:00Z",
+      "summary": "Instrumented modular workflow components with structured debugging logs for stage blueprint, evidence cycles, pre-writing packets, and document object map packets."
     }
   ]
 }

--- a/src/lawyerfactory/agents/orchestration/maestro.py
+++ b/src/lawyerfactory/agents/orchestration/maestro.py
@@ -102,10 +102,10 @@ class Maestro:
         )
         records = [
             EvidenceRecord(
-                evidence_id=item.get("evidence_id", f"evidence_{index}"),
-                summary=item.get("summary", ""),
-                source_type=item.get("source_type", "unknown"),
-                tier=item.get("tier", "secondary"),
+                evidence_id=str(item.get("evidence_id") or f"evidence_{index}"),
+                summary=str(item.get("summary") or ""),
+                source_type=str(item.get("source_type") or "unknown"),
+                tier=str(item.get("tier") or "secondary"),
             )
             for index, item in enumerate(evidence_items)
         ]
@@ -132,13 +132,13 @@ class Maestro:
         for index, section in enumerate(claim_sections):
             document_map.add_section(
                 SectionNode(
-                    section_id=section.get("section_id", f"section_{index:03d}"),
-                    claim_id=section.get("claim_id", "unscoped_claim"),
-                    theory_id=section.get("theory_id", "default_theory"),
-                    title=section.get("title", "Untitled Section"),
-                    body=section.get("body", ""),
-                    summary=section.get("summary", ""),
-                    tags=section.get("tags", []),
+                    section_id=section.get("section_id") or f"section_{index:03d}",
+                    claim_id=section.get("claim_id") or "unscoped_claim",
+                    theory_id=section.get("theory_id") or "default_theory",
+                    title=section.get("title") or "Untitled Section",
+                    body=section.get("body") or "",
+                    summary=section.get("summary") or "",
+                    tags=[str(t) for t in (section.get("tags") or [])],
                 )
             )
 
@@ -217,11 +217,16 @@ class Maestro:
 
         Args:
             workflow_id: The workflow to orchestrate
-            phase_id: Phase to execute (e.g., "A01_intake", "A02_research")
+            phase_id: Phase to execute (e.g., "phaseA01_intake", "phaseA02_research").
+                      Short-form IDs without the "phase" prefix (e.g. "A01_intake") are
+                      also accepted and will be normalized automatically.
 
         Returns:
             Phase execution results
         """
+        # Normalize phase_id to match phase_sequence keys (phaseXXX_ prefix required)
+        if not phase_id.startswith("phase"):
+            phase_id = f"phase{phase_id}"
         try:
             if workflow_id not in self.active_workflows:
                 raise ValueError(f"Workflow {workflow_id} not found")

--- a/src/lawyerfactory/compose/maestro/document_object_map.py
+++ b/src/lawyerfactory/compose/maestro/document_object_map.py
@@ -1,0 +1,147 @@
+"""Document object map utilities for long-form modular drafting."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _fingerprint(text: str) -> str:
+    return hashlib.sha1(text.strip().lower().encode("utf-8")).hexdigest()[:12]
+
+
+def _token_estimate(text: str) -> int:
+    # Fast approximation for context-window packing.
+    return max(1, len(text.split()))
+
+
+@dataclass(frozen=True)
+class SectionLink:
+    """Link between an underlying claim and one of its theory sections."""
+
+    claim_id: str
+    theory_id: str
+    section_id: str
+
+
+@dataclass
+class SectionNode:
+    """Single document section tracked in the object map."""
+
+    section_id: str
+    claim_id: str
+    theory_id: str
+    title: str
+    body: str
+    summary: str
+    tags: list[str] = field(default_factory=list)
+
+    @property
+    def body_fingerprint(self) -> str:
+        return _fingerprint(self.body)
+
+
+@dataclass
+class DocumentObjectMap:
+    """Tracks section locations, overlap detection, and context compression."""
+
+    sections: list[SectionNode] = field(default_factory=list)
+
+    def add_section(self, section: SectionNode) -> None:
+        self.sections.append(section)
+        logger.debug(
+            "Added section to document object map",
+            extra={
+                "section_id": section.section_id,
+                "claim_id": section.claim_id,
+                "theory_id": section.theory_id,
+                "total_sections": len(self.sections),
+            },
+        )
+
+    def linked_sections(self) -> list[SectionLink]:
+        return [
+            SectionLink(
+                claim_id=section.claim_id,
+                theory_id=section.theory_id,
+                section_id=section.section_id,
+            )
+            for section in self.sections
+        ]
+
+    def overlap_report(self) -> dict[str, Any]:
+        seen: dict[str, str] = {}
+        duplicates: list[dict[str, str]] = []
+        for section in self.sections:
+            fingerprint = section.body_fingerprint
+            if fingerprint in seen:
+                duplicates.append(
+                    {
+                        "section_id": section.section_id,
+                        "duplicates_section_id": seen[fingerprint],
+                    }
+                )
+            else:
+                seen[fingerprint] = section.section_id
+        report = {
+            "has_overlap": len(duplicates) > 0,
+            "duplicate_pairs": duplicates,
+            "section_count": len(self.sections),
+        }
+        if report["has_overlap"]:
+            logger.warning(
+                "Detected overlapping section content in document object map",
+                extra={
+                    "duplicate_count": len(duplicates),
+                    "section_count": len(self.sections),
+                },
+            )
+        else:
+            logger.debug(
+                "No overlaps detected in document object map",
+                extra={"section_count": len(self.sections)},
+            )
+        return report
+
+    def build_context_packet(self, token_budget: int = 900) -> dict[str, Any]:
+        ordered = sorted(self.sections, key=lambda item: item.section_id)
+        packed_sections: list[dict[str, Any]] = []
+        consumed = 0
+
+        for section in ordered:
+            summary_tokens = _token_estimate(section.summary)
+            if consumed + summary_tokens > token_budget:
+                break
+            consumed += summary_tokens
+            packed_sections.append(
+                {
+                    "section_id": section.section_id,
+                    "claim_id": section.claim_id,
+                    "theory_id": section.theory_id,
+                    "title": section.title,
+                    "summary": section.summary,
+                    "tags": sorted(set(section.tags)),
+                }
+            )
+
+        packet = {
+            "token_budget": token_budget,
+            "consumed_tokens": consumed,
+            "sections": packed_sections,
+            "overlap_report": self.overlap_report(),
+            "links": [link.__dict__ for link in self.linked_sections()],
+        }
+        logger.info(
+            "Built document context packet",
+            extra={
+                "token_budget": token_budget,
+                "consumed_tokens": consumed,
+                "packed_sections": len(packed_sections),
+                "total_sections": len(self.sections),
+            },
+        )
+        return packet

--- a/src/lawyerfactory/compose/maestro/document_object_map.py
+++ b/src/lawyerfactory/compose/maestro/document_object_map.py
@@ -82,7 +82,7 @@ class DocumentObjectMap:
                 duplicates.append(
                     {
                         "section_id": section.section_id,
-                        "duplicates_section_id": seen[fingerprint],
+                        "duplicate_of_section_id": seen[fingerprint],
                     }
                 )
             else:

--- a/src/lawyerfactory/compose/maestro/lawsuit_blueprint.py
+++ b/src/lawyerfactory/compose/maestro/lawsuit_blueprint.py
@@ -1,0 +1,238 @@
+"""Stage-based lawsuit assembly blueprint for multi-agent orchestration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .prewriting_packets import PREWRITING_DELIVERABLE_IDS
+
+logger = logging.getLogger(__name__)
+
+EVIDENCE_TIERS = ("primary", "secondary", "tertiary")
+
+
+@dataclass(frozen=True)
+class AgentRole:
+    """Defines a role in the multi-agent network for a phase."""
+
+    role_id: str
+    title: str
+    responsibility: str
+
+
+@dataclass(frozen=True)
+class BlueprintPhase:
+    """A discrete, combinable phase in the lawsuit assembly workflow."""
+
+    phase_id: str
+    label: str
+    objective: str
+    required_inputs: list[str]
+    outputs: list[str]
+    agents: list[AgentRole]
+    can_iterate: bool = True
+
+
+@dataclass
+class EvidenceRecord:
+    """Minimal evidence payload used for planning and tier categorization."""
+
+    evidence_id: str
+    summary: str
+    source_type: str
+    tier: str = field(default="secondary")
+
+    def normalized_tier(self) -> str:
+        normalized = (self.tier or "secondary").lower()
+        return normalized if normalized in EVIDENCE_TIERS else "secondary"
+
+
+def get_lawsuit_stage_blueprint() -> list[BlueprintPhase]:
+    """Return ordered phases for evidence-to-lawsuit compilation.
+
+    The first role in every phase is the Head Partner/Maestro/Architect, allowing
+    a consistent supervisory control-plane with specialized worker agents.
+    """
+
+    head_partner = AgentRole(
+        role_id="head_partner_maestro_architect",
+        title="Head Partner / Maestro / Architect",
+        responsibility="Direct phase sequencing, quality gates, and escalation.",
+    )
+
+    phases = [
+        BlueprintPhase(
+            phase_id="P01_evidence_rag_ingestion",
+            label="Evidence Ingestion + RAG Indexing",
+            objective=(
+                "Ingest evidence, classify primary/secondary/tertiary tiers, and "
+                "construct retrieval-ready chunks for downstream reasoning."
+            ),
+            required_inputs=["raw_evidence"],
+            outputs=["tiered_evidence", "rag_index", "ingestion_audit_log"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="evidence_intake_specialist",
+                    title="Evidence Intake Specialist",
+                    responsibility="Normalize uploads and extract canonical metadata.",
+                ),
+                AgentRole(
+                    role_id="retrieval_engineer",
+                    title="RAG Retrieval Engineer",
+                    responsibility="Chunk, embed, and index evidence corpus.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P01b_prewriting_review",
+            label="Pre-Writing Review",
+            objective=(
+                "Produce the three user-reviewable pre-writing deliverables before drafting."
+            ),
+            required_inputs=["tiered_evidence", "rag_index"],
+            outputs=list(PREWRITING_DELIVERABLE_IDS) + ["prewriting_review_packet"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="prewriting_packet_curator",
+                    title="Pre-Writing Packet Curator",
+                    responsibility="Consolidate evidence, issues, and claim theories for review.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P02_issue_spot",
+            label="Issue Spotting",
+            objective="Detect legal issues from tiered evidence and produce issue map.",
+            required_inputs=["tiered_evidence", "rag_index"],
+            outputs=["issue_map", "research_questions"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="issue_spotter",
+                    title="Issue Spotter",
+                    responsibility="Surface potential claims, defenses, and procedural risks.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P03_analysis",
+            label="Legal Analysis",
+            objective="Analyze issues against law, jurisdiction, and burden elements.",
+            required_inputs=["issue_map", "research_questions", "rag_index"],
+            outputs=["analysis_memos", "element_gaps"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="legal_analyst",
+                    title="Legal Analyst",
+                    responsibility="Apply rule statements and evaluate evidentiary sufficiency.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P04_fact_lists",
+            label="Fact List Construction",
+            objective="Convert analyzed evidence into admissibility-aware fact lists.",
+            required_inputs=["analysis_memos", "tiered_evidence"],
+            outputs=["fact_lists", "fact_citations"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="fact_matrix_agent",
+                    title="Fact Matrix Agent",
+                    responsibility="Build numbered factual chronology with source attribution.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P05_causes_of_action",
+            label="Cause of Action Assembly",
+            objective="Map facts to causes of action and required legal elements.",
+            required_inputs=["fact_lists", "analysis_memos"],
+            outputs=["cause_of_action_matrix", "element_support_table"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="claims_engine",
+                    title="Cause of Action Specialist",
+                    responsibility="Draft claim-by-claim element support and gap flags.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P06_top_sheet",
+            label="Top Sheet Generation",
+            objective="Create filing top sheet and litigation packet metadata.",
+            required_inputs=["cause_of_action_matrix", "fact_lists"],
+            outputs=["top_sheet", "filing_metadata"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="filing_packet_specialist",
+                    title="Filing Packet Specialist",
+                    responsibility="Prepare court header data and relief summary.",
+                ),
+            ],
+        ),
+        BlueprintPhase(
+            phase_id="P07_compile",
+            label="Compilation",
+            objective="Compile final lawsuit in modular sections into filing-ready package.",
+            required_inputs=["top_sheet", "cause_of_action_matrix", "fact_lists"],
+            outputs=["compiled_lawsuit", "quality_manifest"],
+            agents=[
+                head_partner,
+                AgentRole(
+                    role_id="compilation_editor",
+                    title="Compilation Editor",
+                    responsibility="Assemble sections, validate references, and finalize output.",
+                ),
+            ],
+            can_iterate=False,
+        ),
+    ]
+    logger.info(
+        "Built lawsuit stage blueprint",
+        extra={
+            "phase_count": len(phases),
+            "phase_ids": [phase.phase_id for phase in phases],
+        },
+    )
+    return phases
+
+
+def build_evidence_cycle(records: Iterable[EvidenceRecord]) -> dict[str, Any]:
+    """Build an iteration cycle payload that drives repeated ingest/classify passes."""
+
+    cycle: dict[str, Any] = {tier: [] for tier in EVIDENCE_TIERS}
+    for record in records:
+        tier = record.normalized_tier()
+        cycle[tier].append(
+            {
+                "evidence_id": record.evidence_id,
+                "summary": record.summary,
+                "source_type": record.source_type,
+            }
+        )
+
+    total_items = sum(len(items) for items in cycle.values())
+    payload = {
+        "evidence_cycle": cycle,
+        "counts": {tier: len(items) for tier, items in cycle.items()},
+        "total_items": total_items,
+        "requires_additional_ingest": total_items == 0,
+    }
+    logger.info(
+        "Built evidence cycle payload",
+        extra={
+            "total_items": total_items,
+            "counts": payload["counts"],
+            "requires_additional_ingest": payload["requires_additional_ingest"],
+        },
+    )
+    return payload

--- a/src/lawyerfactory/compose/maestro/prewriting_packets.py
+++ b/src/lawyerfactory/compose/maestro/prewriting_packets.py
@@ -1,0 +1,76 @@
+"""Pre-writing deliverable packets for user review before drafting."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PREWRITING_DELIVERABLE_IDS = (
+    "evidence_reliability_brief",
+    "issue_fact_matrix",
+    "claim_theory_strategy_sheet",
+)
+
+
+@dataclass(frozen=True)
+class PreWritingDeliverable:
+    """Single pre-writing deliverable payload."""
+
+    deliverable_id: str
+    title: str
+    purpose: str
+    sections: list[str]
+
+
+def build_prewriting_deliverables() -> list[PreWritingDeliverable]:
+    """Return 3 user-facing deliverables that gate drafting."""
+    deliverables = [
+        PreWritingDeliverable(
+            deliverable_id="evidence_reliability_brief",
+            title="Evidence Reliability Brief",
+            purpose="Summarizes primary/secondary/tertiary evidence confidence and gaps.",
+            sections=["tier_counts", "source_credibility", "missing_evidence_actions"],
+        ),
+        PreWritingDeliverable(
+            deliverable_id="issue_fact_matrix",
+            title="Issue-to-Fact Matrix",
+            purpose="Maps spotted issues to supporting facts and citations.",
+            sections=["issue_list", "supporting_facts", "open_questions"],
+        ),
+        PreWritingDeliverable(
+            deliverable_id="claim_theory_strategy_sheet",
+            title="Claim Theory Strategy Sheet",
+            purpose="Defines each underlying claim and the legal theories that support it.",
+            sections=["underlying_claims", "theory_variants", "element_support"],
+        ),
+    ]
+    logger.debug(
+        "Built pre-writing deliverables",
+        extra={
+            "deliverable_ids": [item.deliverable_id for item in deliverables],
+            "deliverable_count": len(deliverables),
+        },
+    )
+    return deliverables
+
+
+def to_user_review_packet() -> dict[str, Any]:
+    """Serialize deliverables for UI/API review checkpoint."""
+
+    deliverables = build_prewriting_deliverables()
+    packet = {
+        "deliverable_count": len(deliverables),
+        "deliverables": [item.__dict__ for item in deliverables],
+        "ready_for_user_review": True,
+    }
+    logger.info(
+        "Prepared pre-writing review packet",
+        extra={
+            "deliverable_count": packet["deliverable_count"],
+            "ready_for_user_review": packet["ready_for_user_review"],
+        },
+    )
+    return packet

--- a/tests/unit/test_document_object_map.py
+++ b/tests/unit/test_document_object_map.py
@@ -1,0 +1,45 @@
+from lawyerfactory.compose.maestro.document_object_map import DocumentObjectMap, SectionNode
+
+
+def test_document_map_detects_duplicates_and_builds_links():
+    document_map = DocumentObjectMap()
+    document_map.add_section(
+        SectionNode(
+            section_id="S1",
+            claim_id="C1",
+            theory_id="T1",
+            title="Claim One",
+            body="Repeated body text",
+            summary="Summary one",
+            tags=["claim"],
+        )
+    )
+    document_map.add_section(
+        SectionNode(
+            section_id="S2",
+            claim_id="C1",
+            theory_id="T2",
+            title="Claim One Theory Two",
+            body="Repeated body text",
+            summary="Summary two",
+            tags=["theory"],
+        )
+    )
+
+    packet = document_map.build_context_packet(token_budget=50)
+
+    assert packet["overlap_report"]["has_overlap"] is True
+    assert len(packet["links"]) == 2
+    assert packet["sections"][0]["claim_id"] == "C1"
+
+
+def test_document_map_respects_token_budget():
+    document_map = DocumentObjectMap(
+        sections=[
+            SectionNode("S1", "C1", "T1", "A", "Body", "one two three"),
+            SectionNode("S2", "C2", "T2", "B", "Body", "four five six"),
+        ]
+    )
+
+    packet = document_map.build_context_packet(token_budget=3)
+    assert len(packet["sections"]) == 1

--- a/tests/unit/test_lawsuit_blueprint.py
+++ b/tests/unit/test_lawsuit_blueprint.py
@@ -1,0 +1,38 @@
+from lawyerfactory.compose.maestro.lawsuit_blueprint import (
+    EvidenceRecord,
+    build_evidence_cycle,
+    get_lawsuit_stage_blueprint,
+)
+
+
+def test_lawsuit_stage_blueprint_contains_required_pipeline_steps():
+    phases = get_lawsuit_stage_blueprint()
+    phase_ids = [phase.phase_id for phase in phases]
+
+    assert phase_ids == [
+        "P01_evidence_rag_ingestion",
+        "P01b_prewriting_review",
+        "P02_issue_spot",
+        "P03_analysis",
+        "P04_fact_lists",
+        "P05_causes_of_action",
+        "P06_top_sheet",
+        "P07_compile",
+    ]
+
+    for phase in phases:
+        assert phase.agents[0].role_id == "head_partner_maestro_architect"
+
+
+def test_build_evidence_cycle_normalizes_unknown_tiers_to_secondary():
+    cycle_payload = build_evidence_cycle(
+        [
+            EvidenceRecord("E1", "Contract", "document", "primary"),
+            EvidenceRecord("E2", "Summary", "note", "unsupported"),
+            EvidenceRecord("E3", "Witness", "interview", "tertiary"),
+        ]
+    )
+
+    assert cycle_payload["counts"] == {"primary": 1, "secondary": 1, "tertiary": 1}
+    assert cycle_payload["total_items"] == 3
+    assert cycle_payload["requires_additional_ingest"] is False

--- a/tests/unit/test_maestro_modular_outputs.py
+++ b/tests/unit/test_maestro_modular_outputs.py
@@ -1,0 +1,32 @@
+from lawyerfactory.agents.orchestration.maestro import Maestro
+
+
+def test_maestro_prewriting_packet_and_stage_blueprint_exposed():
+    maestro = object.__new__(Maestro)
+
+    packet = maestro.get_prewriting_review_packet()
+    phases = maestro.get_stage_blueprint()
+
+    assert packet["deliverable_count"] == 3
+    assert phases[1]["phase_id"] == "P01b_prewriting_review"
+
+
+def test_maestro_document_object_map_links_claim_and_theory():
+    maestro = object.__new__(Maestro)
+    result = maestro.build_document_object_map(
+        [
+            {
+                "section_id": "S-101",
+                "claim_id": "claim-fraud",
+                "theory_id": "theory-concealment",
+                "title": "Fraud by Concealment",
+                "body": "Body text",
+                "summary": "Condensed summary",
+                "tags": ["fraud"],
+            }
+        ],
+        token_budget=20,
+    )
+
+    assert result["sections"][0]["section_id"] == "S-101"
+    assert result["links"][0]["claim_id"] == "claim-fraud"

--- a/tests/unit/test_prewriting_packets.py
+++ b/tests/unit/test_prewriting_packets.py
@@ -1,0 +1,13 @@
+from lawyerfactory.compose.maestro.prewriting_packets import (
+    PREWRITING_DELIVERABLE_IDS,
+    to_user_review_packet,
+)
+
+
+def test_prewriting_review_packet_has_three_deliverables():
+    packet = to_user_review_packet()
+
+    assert packet["deliverable_count"] == 3
+    assert packet["ready_for_user_review"] is True
+    ids = [item["deliverable_id"] for item in packet["deliverables"]]
+    assert tuple(ids) == PREWRITING_DELIVERABLE_IDS


### PR DESCRIPTION
### Motivation
- Introduce a modular, stage-based blueprint to express discrete lawsuit assembly phases and enforce phase order for orchestrated multi-agent workflows. 
- Provide pre-writing user-review gating and evidence cycling to improve evidence triage and prevent drafting before required deliverables are reviewed. 
- Support long-form composition with a document object map that detects overlap and produces context-window-safe packets while exposing accessors from the central Maestro agent.

### Description
- Added `src/lawyerfactory/compose/maestro/lawsuit_blueprint.py` implementing `BlueprintPhase`, `AgentRole`, `EvidenceRecord`, `get_lawsuit_stage_blueprint`, and `build_evidence_cycle` to define phases and build tiered evidence cycles. 
- Added `src/lawyerfactory/compose/maestro/document_object_map.py` implementing `DocumentObjectMap`, `SectionNode`, overlap detection, and `build_context_packet` for token-budget-safe section packing. 
- Added `src/lawyerfactory/compose/maestro/prewriting_packets.py` implementing three pre-writing deliverables and `to_user_review_packet` for the user-review gate. 
- Updated `src/lawyerfactory/agents/orchestration/maestro.py` to import and expose new APIs via `get_stage_blueprint`, `build_evidence_cycle_payload`, `build_document_object_map`, and `get_prewriting_review_packet`, moved the enhanced storage shim import into `__init__`, tightened type hints, and ensured workflow initialization aligns `current_phase` to the phase sequence start. 
- Updated `docs/knowledge_graph_state.json` to document the new components, features, relations, notes, and update history. 

### Testing
- Ran the unit test suite for the added modules with `pytest tests/unit` and all new unit tests (`test_document_object_map.py`, `test_lawsuit_blueprint.py`, `test_maestro_modular_outputs.py`, `test_prewriting_packets.py`) passed. 
- No additional automated e2e tests were executed as part of this rollout; linting remains blocked by the documented Ruff backlog.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dee8c900832a9b773a4e0e9619c4)